### PR TITLE
unregister listeners when component is unmounted

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -57,6 +57,10 @@ export default class StickyBox extends React.Component {
     }
   }
 
+  componentWillUnmount(){
+    this.registerContainerRef(null);
+  }
+
   registerContainerRef = n => {
     if (!stickyProp) return;
     this.node = n;


### PR DESCRIPTION
I believe this is the change that is required to eliminate the listener issue that is filling roller with errors. 

I have opened a parallel PR back to the project; but timing is uncertain.

I don't know enough about npm packaging or yarn to quickly figure out how to release a fork like this for use until the parent project is updated. But if anyone has a time boxed amount of time they want to spend on something semi-tangential it would be welcome.  

(FYI: this repo/PR is public due to the fork) 
